### PR TITLE
Chatbot - SW whitelisting for cbot API's

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -97,7 +97,7 @@ self.addEventListener('fetch', async (event) => {
   const hostURL = new URL(self.location);
   const { request } = event;
   // Check if the request is an API request with a different port
-  if (((request.url.includes('api') && !request.url.includes('chrome-extension')) || request.url.includes('EnvironmentVariableServlet')) && hostURL.port !== '4502') {
+  if (((request.url.includes('api') && !request.url.includes('cbot') && !request.url.includes('chrome-extension')) || request.url.includes('EnvironmentVariableServlet')) && hostURL.port !== '4502') {
     const paths = request.url.split('/');
     console.log('[sw.js] fetch: API request and not from the port 4502 =>', request.url);
     if (tokens.includes(paths[paths.length - 1])) {


### PR DESCRIPTION
Added chat api's in SW whitelisting - SW workaround will be removes once subdomain mapping is done.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #39 

Test URLs:
- Before: https://main--airindia--hlxsites.hlx.live/in/en/book/special-offers/global-connectivity
- After: https://chat-fix--airindia--hlxsites.hlx.live/in/en/book/special-offers/global-connectivity
